### PR TITLE
Update demo-select2-with-bootstrap's multiple option

### DIFF
--- a/docs/examples/demo-select2-with-bootstrap.html
+++ b/docs/examples/demo-select2-with-bootstrap.html
@@ -1,4 +1,5 @@
 ﻿  <p>Selected: {{ctrl.person.selected.name}}</p>
+﻿  <p>Multiple selected: <span ng-repeat="selected in ctrl.multipleDemo.selectedPeople" ng-bind="($first ? '' : ', ') + selected.name"></span></p>
 
   <form class="form-horizontal">
     <fieldset>
@@ -23,8 +24,8 @@
         <label class="col-sm-3 control-label">Multiple</label>
         <div class="col-sm-6">
 
-          <ui-select multiple sortable="true" ng-model="ctrl.person.selected" theme="select2" class="form-control" title="Choose a person">
-            <ui-select-match placeholder="Select or search a person in the list...">{{$select.selected.name}}</ui-select-match>
+          <ui-select multiple sortable="true" ng-model="ctrl.multipleDemo.selectedPeople" theme="select2" class="form-control" title="Choose a person">
+            <ui-select-match placeholder="Select or search a person in the list...">{{$item.name}}</ui-select-match>
             <ui-select-choices repeat="item in ctrl.people | filter: $select.search">
               <div ng-bind-html="item.name | highlight: $select.search"></div>
               <small ng-bind-html="item.email | highlight: $select.search"></small>


### PR DESCRIPTION
Currently the "multiple" option is coded to expect a single object rather than an array of objects. This PR would change it to instead use one of the multiple options and not be visibly broken.

Desired end result: http://plnkr.co/edit/1QhCyELNKQfYRDZyi5se?p=preview
